### PR TITLE
refactor: :recycle: uses model actors for all writing

### DIFF
--- a/AppPackages/DataStorage/Sources/DataStorage/BackgroundActors/ExerciseListActor.swift
+++ b/AppPackages/DataStorage/Sources/DataStorage/BackgroundActors/ExerciseListActor.swift
@@ -32,6 +32,27 @@ extension ExerciseList {
 			}
 		}
 
+		public func addOrRemoveExercise(
+			exerciseID: PersistentIdentifier, from listID: PersistentIdentifier
+		) throws {
+			// Get the exercise from the exerciseID
+			guard let exercise = self[exerciseID, as: Exercise.self] else {
+				print("\(#file) \(#function) \(exerciseID) not found")
+				return
+			}
+			// Get the list and make sure it exists
+			guard let list = self[listID, as: ExerciseList.self] else {
+				print("\(#file) \(#function) \(listID) not found")
+				return
+			}
+			if list.exercises.contains(exercise) {
+				list.exercises.remove(at: list.exercises.firstIndex(of: exercise)!)
+			} else {
+				list.exercises.append(exercise)
+			}
+			try save()
+		}
+
 		/// Save the current modelContext
 		/// - Throws: Any errors that occur during the save operation
 		///

--- a/AppPackages/DataStorage/Sources/DataStorage/BackgroundActors/ExerciseListActor.swift
+++ b/AppPackages/DataStorage/Sources/DataStorage/BackgroundActors/ExerciseListActor.swift
@@ -14,6 +14,12 @@ extension ExerciseList {
 	/// This service is responsible for managing ExerciseLists in the database. It is used to do any writing to the database.
 	@ModelActor
 	public actor Service {
+		/// Add a list with the given name, description, and icon
+		public func saveList(name: String, summary: String, icon: String) throws {
+			let list = ExerciseList(name: name, summary: summary, icon: icon)
+			modelContext.insert(list)
+			try save()
+		}
 		/// Delete lists for given persistent identifiers
 		public func deleteList(for ids: [PersistentIdentifier]) throws {
 			for id in ids {

--- a/AppPackages/DataStorage/Sources/DataStorage/BackgroundActors/ExerciseSetActor.swift
+++ b/AppPackages/DataStorage/Sources/DataStorage/BackgroundActors/ExerciseSetActor.swift
@@ -39,13 +39,20 @@ extension ExerciseSet {
 				print("\(#file) \(#function) \(exerciseID) not found")
 				return
 			}
+			let dateCompleted = Date.now
 			let newSet = ExerciseSet(
 				reps: reps,
 				weight: weight,
-				dateCompleted: .now
+				dateCompleted: dateCompleted
 			)
 			modelContext.insert(newSet)
 			exercise.sets.append(newSet)
+
+			// update exercise list ids
+			for exerciseList in exercise.lists {
+				exerciseList.lastCompletedDate = dateCompleted
+			}
+
 			try save()
 		}
 

--- a/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseListDetailView.swift
+++ b/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseListDetailView.swift
@@ -20,13 +20,6 @@ struct ExerciseListDetailView: View {
 			if exerciseList.exercises.isEmpty {
 				NavigationLink("No exercises yet! Add one!") {
 					SelectExerciseView(nameOfList: exerciseList.name)
-						.onDisappear {
-							do {
-								try modelContext.save()
-							} catch {
-								print(#file, #function, "Error saving model: \(error)")
-							}
-						}
 				}
 			}
 			ForEach(exerciseList.exercises) { exercise in

--- a/AppPackages/Exercises/Sources/Exercises/ExerciseLists/SelectExerciseView.swift
+++ b/AppPackages/Exercises/Sources/Exercises/ExerciseLists/SelectExerciseView.swift
@@ -67,13 +67,23 @@ struct SelectExerciseView: View {
 	}
 
 	func select(exercise: Exercise) {
+		let container = modelContext.container
+		let exerciseListID = exerciseLists.first!.id
+		let exerciseID = exercise.id
+
+		Task.detached(priority: .userInitiated) {
+			let service = ExerciseList.Service(modelContainer: container)
+			do {
+				try await service.addOrRemoveExercise(exerciseID: exerciseID, from: exerciseListID)
+			} catch {
+				print("🚨 \(#function) \(#file) Error adding exercise to list: \(error)")
+			}
+		}
 		if selectedExercises.contains(where: { $0 == exercise }) {
 			selectedExercises.removeAll(where: { $0 == exercise })
 		} else {
 			selectedExercises.append(exercise)
 		}
-		// Auto update exerciseList
-		exerciseLists.first?.exercises = selectedExercises
 	}
 }
 

--- a/AppPackages/Exercises/Sources/Exercises/SetsAndReps/NewSetView.swift
+++ b/AppPackages/Exercises/Sources/Exercises/SetsAndReps/NewSetView.swift
@@ -141,27 +141,17 @@ extension NewSetView {
 // Functions
 extension NewSetView {
 	func save() {
-		let completedDate: Date = .now
-		let newSet = ExerciseSet(
-			reps: reps,
-			weight: weight,
-			dateCompleted: completedDate
-		)
-
-		// Add the set to the context
-		modelContext.insert(newSet)
-		// Add it to the exercises
-		exercise.sets.append(newSet)
-
-		for exerciseList in exercise.lists {
-			exerciseList.lastCompletedDate = completedDate
-		}
-
-		do {
-			try modelContext.save()
-			dismiss()
-		} catch {
-			print("Error saving new set: \(error.localizedDescription)")
+		let container = modelContext.container
+		let exerciseID = exercise.id
+		let reps = reps
+		let weight = weight
+		Task.detached(priority: .userInitiated) {
+			let service = ExerciseSet.Service(modelContainer: container)
+			do {
+				try await service.addSet(for: exerciseID, weight: weight, reps: reps)
+			} catch {
+				print("Error saving set: \(error)")
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Your title should be in the format of "feat(scope): description" -->

## Description
<!--- Describe your changes in detail -->
- **refactor: :recycle: use actor to write exercise list**
- **refactor: :recycle: use actor to update lists in exercise**
- **refactor: :recycle: use actor for new set**

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This starts the pattern of using a background actor to do all writing and all reading will be done on the main actor.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in a discussion first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #38 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested... at some point tests should be written for all Services

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Only one box should be checked -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer tooling (fix or improve developer tooling)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
