### PR TITLE
chore(format): :wrench: Modified scripts to support the new swift format in Xcode 16 toolchain

### DIFF
--- a/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseListView.swift
+++ b/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseListView.swift
@@ -49,7 +49,8 @@ public struct ExerciseListView: View {
 
 				ToolbarItem {
 					Menu("Menu", systemImage: "note.text") {
-						Button {} label: {
+						Button {
+						} label: {
 							Text("Sort")
 						}
 					}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "prepare": "husky .",
     "emojify": "npx --no-install devmoji -e --format shortcode",
-    "format": "find . -name \"*.swift\" -print0 | xargs -0 swift-format --in-place --configuration .swift-format.json",
-    "format-changes": ". ./scripts/format-changes.sh"
+    "format": ". ./scripts/format.sh",
+    "format-changes": ". ./scripts/format.sh --changes"
   },
   "author": "heyjaywilson",
   "license": "Apache-2.0",

--- a/scripts/format-changes.sh
+++ b/scripts/format-changes.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env sh
-
-git diff --diff-filter=d --staged --name-only | grep -e '\(.*\).swift$' | while read line; do
-    swift-format format --configuration .swift-format.json -i "${line}";
-    git add "$line";
-done

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+
+# Check if "--changes" param is passed
+if [ "$1" = "--changes" ]; then
+    FORMAT_CHANGES=true
+else
+    FORMAT_CHANGES=false
+fi
+
+XCODE_VERSION=$(xcodebuild -version | grep 'Xcode' | awk '{print $2}' | cut -d '.' -f1)
+
+# Determine swift format command based on Xcode version
+if [ "$XCODE_VERSION" -ge 16 ]; then
+    SWIFT_FORMAT_CMD="swift format"
+else
+    if ! command -v swift-format > /dev/null 2>&1; then
+        echo "Error: 'swift-format' is not installed. Please install it or use Xcode 16 or greater."
+        exit 1
+    fi
+    SWIFT_FORMAT_CMD="swift-format"
+fi
+
+# Format based on the param
+if [ "$FORMAT_CHANGES" = true ]; then
+    echo "Formatting staged Swift changes..."
+    git diff --staged --name-only --diff-filter=AM -- "*.swift" | while read line; do
+        echo "Formatting $line"
+        $SWIFT_FORMAT_CMD format --configuration .swift-format.json -i "${line}"
+        git add "$line"
+    done
+else
+    echo "Formatting all Swift files in the project..."
+    find . -name "*.swift" | while read line; do
+        echo "Formatting $line"
+        $SWIFT_FORMAT_CMD format --configuration .swift-format.json -i "${line}"
+    done
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Your title should be in the format of "feat(scope): description" -->

## Description
<!--- Describe your changes in detail -->

### The problem 

Xcode 16 and above include swift-format in the toolchain. You can run swift-format from anywhere on the system using `swift format` (notice the space instead of dash). Because of this, it is not necessary to install swift-format using Homebrew or other custom alternatives. The difference is that to invoke the command you have to use swift format instead of swift-format.

With the current setup, if you try to run the scripts without a custom `swift-format` installation, you would get an error saying that `swift-format` isn't installed, which is not true if you have Xcode 16. 

### The solution 

We want to take advantage of the new toolchain for Xcode 16 containing swift-format, so I have made the next changes: 

* The script now checks the Xcode version and use the right command based on that, not requiring a custom installation if devs are using Xcode 16 
* If you are not using Xcode 16 and the dev doesn't have swift-format installed, it will print a clear error message asking to install it or to use Xcode 16 

### Enhancements 

The package file was invoking two different shell scripts for formatting all the files and for formatting only the changes. In the case of `format-changes`, it was invoking `scripts/format-changes.sh`. In the other case the script was declared in the `package.json` itself. This isn't ideal since it is using different approaches for both cases and we have to maintain two different scripts in different places. 

I have unified those two scripts in a single `scripts/format.sh` file, so it is cleaner and we have only one script to maintain—especially now that we have to check the Xcode version in both cases. 

The new `format.sh` script can format every file in the project, or can modify only the changes if it receives the `--changes` flag. 

### Bonus 

I have fixed the file `ExerciseListView.swift` that wasn't well formatted. 
 
### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in a discussion first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- If this Pull Request closes an issue, please add `Closes #XXXX` -->

Closes #51 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

To test this I have modified the indentation of several files, add them to the git stage and then: 
- [x] Run the script manually only for the changes 
- [x] Run the script manually for the entire project 
- [x] Made a test commit to check that it format the files changed correctly 

Additionally, I have tested with the next environments: 
- [x] Setting Xcode 16 using `xcode-select -s` -> Scripts worked correctly using `swift format`
- [x] Setting Xcode 15.4 without a custom swift-format installation -> Showed the error asking to install or use Xcode 16
- [x] Setting Xcode 15.4 using `xcode-select -s` -> Scripts worked correctly using `swift-format`

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Only one box should be checked -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer tooling (fix or improve developer tooling)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
