### PR TITLE
fix: :bug: use correct formatting for section titles in exercise detail view

### DIFF
--- a/AppPackages/DataStorage/Sources/DataStorage/Exercise.swift
+++ b/AppPackages/DataStorage/Sources/DataStorage/Exercise.swift
@@ -59,19 +59,38 @@ extension Exercise {
 			for: Exercise.self,
 			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
 		)
-
-		let exercise = Exercise(
+		
+		let exercise = Exercise( // Should contain sets in the future and past
 			name: "Chest Press",
 			sets: [
-				.init(reps: 8, weight: 10, dateCompleted: .now),
-				.init(reps: 8, weight: 5, dateCompleted: .distantPast),
+				// Future
+				.init(reps: 20, weight: 20, dateCompleted: inDays(2)),
+				.init(reps: 20, weight: 20, dateCompleted: inDays(2)),
+				.init(reps: 20, weight: 20, dateCompleted: inDays(2)),
+				// Today
+				.init(reps: 0, weight: 0, dateCompleted: .now),
+				// Past
+				.init(reps: 1, weight: 1, dateCompleted: inDays(-1)),
+				.init(reps: 1, weight: 1, dateCompleted: inDays(-1)),
+				.init(reps: 12, weight: 12, dateCompleted: inDays(-12)),
+				.init(reps: 12, weight: 12, dateCompleted: inDays(-12)),
+				.init(reps: 60, weight: 60, dateCompleted: inDays(-60)),
+				.init(reps: 60, weight: 60, dateCompleted: inDays(-60)),
+				.init(reps: 61, weight: 60, dateCompleted: inDays(-61)),
+				.init(reps: 61, weight: 60, dateCompleted: inDays(-360)),
+				.init(reps: 1000, weight: 1000, dateCompleted: .distantPast),
 			]
 		)
-		let exercise1 = Exercise(name: "Bicep Curl")
-
+		let exercise1 = Exercise(name: "Bicep Curl") // Leave empty
+		
 		container.mainContext.insert(exercise)
 		container.mainContext.insert(exercise1)
-
+		
 		return container
+	}
+	
+	/// Very rough and inaccurate way of getting easy access to days relative to today
+	private static func inDays(_ days: Int) -> Date {
+		Calendar.current.date(byAdding: .day, value: days, to: .now) ?? .now
 	}
 }

--- a/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseDetailView.swift
+++ b/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseDetailView.swift
@@ -11,6 +11,7 @@ import DataStorage
 import Design
 import SwiftData
 import SwiftUI
+import Utilities
 
 struct ExerciseDetailView: View {
 	@Environment(\.modelContext) private var modelContext
@@ -55,15 +56,20 @@ struct ExerciseDetailView: View {
 	}
 }
 
-#Preview(traits: .modifier(ExerciseModelPreviewModifier())) {
+#Preview("Exercise with entries", traits: .modifier(ExerciseModelPreviewModifier())) {
 	@Previewable @Query var exercises: [Exercise]
 
 	NavigationStack {
-		if let exercise = exercises.first {
-			ExerciseDetailView(for: exercise.name)
-		} else {
-			Text("No exercise found")
-		}
+		ExerciseDetailView(for: exercises.first(where: { !$0.sets.isEmpty })!.name)
+	}
+	.modelContainer(Exercise.previewModel)
+}
+
+#Preview("Exercise without entries", traits: .modifier(ExerciseModelPreviewModifier())) {
+	@Previewable @Query var exercises: [Exercise]
+
+	NavigationStack {
+		ExerciseDetailView(for: exercises.first(where: { $0.sets.isEmpty })!.name)
 	}
 	.modelContainer(Exercise.previewModel)
 }
@@ -106,9 +112,7 @@ extension ExerciseDetailView {
 				}
 			} header: {
 				Text(
-					setsByDate.date.formatted(
-						.reference(to: .now, allowedFields: [.year, .month, .day])
-					)
+					setsByDate.date.relativeString(todayString: "Today")
 				)
 				.caption()
 				.bold()

--- a/AppPackages/Utilities/Sources/Utilities/Date.swift
+++ b/AppPackages/Utilities/Sources/Utilities/Date.swift
@@ -64,6 +64,56 @@ extension Date {
 }
 
 extension Date {
+	
+	/// Returns a localized string representing the date relative to a reference date.
+	/// Different formatters are used depending on the actual difference.
+	/// - Parameters:
+	/// 	- todayString: The string to return if the reference is the same as the date.
+	///   - reference: The reference date to compare against. Defaults to `.now`
+	///   - calendar: The calendar to use for relative calculations. Defaults to `.current`
+	/// - Returns: A localized string representing the date
+	public func relativeString(todayString: LocalizedStringResource, from ref: Date = .now, calendar: Calendar = .current) -> String {
+		// We only care about comparisons for the date
+		let current = calendar.startOfDay(for: self)
+		let reference = calendar.startOfDay(for: ref)
+		
+		let standardFormat = current.formatted(date: .long, time: .omitted)
+		let referenceYear = Calendar.current.dateComponents([.year], from: reference)
+		let currentYear = Calendar.current.dateComponents([.year], from: current)
+		
+		guard let daysDifference = Calendar.current.dateComponents([.day], from: current, to: reference).day else {
+			return standardFormat
+		}
+		
+		if daysDifference == 0 {
+			// If the date is the same as the reference, we return the today string.
+			return String(localized: todayString)
+			
+		} else if abs(daysDifference) <= 3 {
+			// After an arbitrary three days difference, we choose not to trust the relative formatter anymore.
+			return formatted(.relative(presentation: .named))
+			
+		} else if referenceYear == currentYear {
+			// If we're still in the same year, showing the year label isn't as helpful.
+			let noYearFormat = Date.FormatStyle()
+				.day(.twoDigits)
+				.month(.wide)
+				.year(.omitted)
+				.hour(.omitted)
+				.minute(.omitted)
+				.second(.omitted)
+			
+			return formatted(noYearFormat)
+
+		} else {
+			// We use the standard representation when we're in a different calendar year.
+			return standardFormat
+			
+		}
+	}
+}
+
+extension Date {
 	/// Use these as dates in SwiftUI previews
 	public struct Constants {
 		/// April 21 2024


### PR DESCRIPTION
Introduces a relativeString method as a Date extension to perform the necessary formatting

Fixes the headers in the ExerciseDetailView to display correct relative strings for the dates

Adds more set entries to the preview model container for exercises

Specifies two previews for ExerciseDetailView, one for an empty view and one for a view with entries

closes: #36 

---

# Notes

After some investigation, I couldn't figure out how to use [reference(to:allowedFields:maxFieldCount:thresholdField:)](https://developer.apple.com/documentation/foundation/formatstyle/4427623-reference) properly, especially since it looks like a very new API which is horribly documented.

Instead, I opted to for a combination of formatters, depending on the difference between `now` and the section date;
1. If the section date is today, we specify "Today" to be used. I opted for a localized string here, because the standard relative formatting uses "Now", which doesn't fit as well.
2. If the section date is three days or less away, we use relative formatting. The three days is arbitrary, but it should be good enough for our purposes.
3. After that, we show the date without the year. The year is obvious information which doesn't need to be repeated.
4. Unless it's actually a different year, where it starts making sense to also show the year.