### PR TITLE
feat: :sparkles: sort exercise lists by list name

### DIFF
--- a/AppPackages/AppEntry/Sources/AppEntry/AppEntry.swift
+++ b/AppPackages/AppEntry/Sources/AppEntry/AppEntry.swift
@@ -18,7 +18,7 @@ public struct AppEntry: View {
 	public var body: some View {
 		TabView {
 			Tab("Sets", systemImage: "dumbbell") {
-				ExerciseListView()
+				ExerciseListContainerView()
 			}
 			Tab("Days", systemImage: "calendar") {
 				DaysView()

--- a/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseListContainerView.swift
+++ b/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseListContainerView.swift
@@ -1,0 +1,54 @@
+// Copyright 2024 CCT Plus LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// -----------------------------------------------------------
+// Project: Exercises
+// Created on 9/11/24 by @HeyJayWilson
+// -----------------------------------------------------------
+
+import DataStorage
+import SwiftData
+import SwiftUI
+
+public struct ExerciseListContainerView: View {
+    @Environment(\.modelContext) private var modelContext
+    
+    // Sorting by name here because I don't have an order field
+    @State private var sortOrder = SortDescriptor(\ExerciseList.name)
+    
+    @State private var showNewListView: Bool = false
+    
+    public init() {}
+    
+    public var body: some View {
+        NavigationStack {
+            ExerciseListView(sortOrder: sortOrder)
+                .navigationTitle("My Lists")
+                .toolbar {
+                    ToolbarItem {
+                        Button("Add list", systemImage: "plus.circle") {
+                            showNewListView = true
+                        }
+                    }
+                    
+                    ToolbarItem {
+                        Menu("Sort", systemImage: "arrow.up.arrow.down") {
+                            Picker("Sort", selection: $sortOrder) {
+                                Text("Alphabetical")
+                                    .tag(SortDescriptor(\ExerciseList.name))
+                            }
+                        }
+                    }
+                }
+                .sheet(isPresented: $showNewListView) {
+                    NewExerciseList()
+                }
+        }
+    }
+}
+
+#Preview {
+    ExerciseListContainerView()
+        .modelContainer(ExerciseList.previewModel)
+}

--- a/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseListView.swift
+++ b/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseListView.swift
@@ -4,68 +4,38 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 // -----------------------------------------------------------
 // Project: Exercises
-// Created on 9/11/24 by @HeyJayWilson
+// Created on 2024-10-10 by @HeyJayWilson
 // -----------------------------------------------------------
 
 import DataStorage
 import SwiftData
 import SwiftUI
 
-public struct ExerciseListView: View {
-	@Environment(\.modelContext) private var modelContext
+struct ExerciseListView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query private var lists: [ExerciseList]
 
-	// Sorting by name here because I don't have an order field
-	@Query(sort: \ExerciseList.name, order: .forward, animation: .default) private var lists:
-		[ExerciseList]
+    init(sortOrder: SortDescriptor<ExerciseList>) {
+        _lists = Query(sort: [sortOrder])
+    }
 
-	@State private var showNewListView: Bool = false
+    var body: some View {
+        List {
+            ForEach(lists) { exerciseList in
+                NavigationLink(destination: ExerciseListDetailView(exerciseList: exerciseList))
+                {
+                    listRow(for: exerciseList)
+                }
+            }
+            .onDelete(perform: deleteList)
 
-	public init() {}
-
-	public var body: some View {
-		NavigationStack {
-			List {
-				ForEach(lists) { exerciseList in
-					NavigationLink(destination: ExerciseListDetailView(exerciseList: exerciseList))
-					{
-						listRow(for: exerciseList)
-					}
-				}
-				.onDelete(perform: deleteList)
-
-				Section {
-					NavigationLink("All Exercises") {
-						AllExercisesListView()
-					}
-				}
-			}
-			.navigationTitle("My Lists")
-			.toolbar {
-				ToolbarItem {
-					Button("Add list", systemImage: "plus.circle") {
-						showNewListView = true
-					}
-				}
-
-				ToolbarItem {
-					Menu("Menu", systemImage: "note.text") {
-						Button {
-						} label: {
-							Text("Sort")
-						}
-					}
-				}
-			}
-			.sheet(isPresented: $showNewListView) {
-				NewExerciseList()
-			}
-		}
-	}
-}
-
-#Preview {
-	ExerciseListView()
-		.modelContainer(ExerciseList.previewModel)
+            Section {
+                NavigationLink("All Exercises") {
+                    AllExercisesListView()
+                }
+            }
+        }
+    }
 }
 
 extension ExerciseListView {
@@ -108,4 +78,8 @@ extension ExerciseListView {
 			}
 		}
 	}
+}
+
+#Preview {
+    ExerciseListView(sortOrder: SortDescriptor(\ExerciseList.name, order: .reverse))
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Your title should be in the format of "feat(scope): description" -->

## Description

The exercise list can now be sorted alphabetically. This has been accomplished by creating a new `ExerciseListContainerView` which contains the `ExerciseListView` to be sorted. From the menu when you pick `Alphabetical` it sets the `$sortOrder` to being a new `SortDescriptor` using the `ExerciseList.name`.  

This work was heavily influenced by: [Sorting query results by Paul Hudson](https://www.hackingwithswift.com/quick-start/swiftdata/sorting-query-results)

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in a discussion first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- If this Pull Request closes an issue, please add `Closes #XXXX` -->

## How Has This Been Tested?
By default when you see the view it’s sorted alphabetically, and when you add something new it add’s it in, in the correct location. So I hacked up reverse alphabetical button, then verified pressing alphabetical correctly sorts the list.

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/8ceb8b7c-bfa6-4b4b-ba7f-19aabdbc2106

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Only one box should be checked -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer tooling (fix or improve developer tooling)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
