### PR TITLE
feat(ExerciseList): :sparkles: add alphabetical sorting for exercises

### DIFF
--- a/AppPackages/DataStorage/Sources/DataStorage/ExerciseList.swift
+++ b/AppPackages/DataStorage/Sources/DataStorage/ExerciseList.swift
@@ -46,6 +46,19 @@ final public class ExerciseList {
 	}
 }
 
+public extension ExerciseList {
+	enum SortOption {
+		case alphabetical
+	}
+
+	func sort(by option: SortOption) {
+		switch option {
+		case .alphabetical:
+			exercises.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+		}
+	}
+}
+
 extension ExerciseList {
 	@MainActor
 	public static var previewModel: ModelContainer {

--- a/AppPackages/DataStorage/Tests/DataStorageTests/ExcerciseListTests.swift
+++ b/AppPackages/DataStorage/Tests/DataStorageTests/ExcerciseListTests.swift
@@ -1,0 +1,48 @@
+//
+// -----------------------------------------------------------
+// Copyright 2024 CCT Plus LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// -----------------------------------------------------------
+// Project: DataStorage
+// Created on 16.10.24
+// -----------------------------------------------------------
+//
+
+import Testing
+import SwiftData
+@testable import DataStorage
+
+struct ExcerciseListTests {
+    @Test("Sort all exercises in list alphabetically")
+	func sortingExercisesAlphabetically() async throws {
+		let config = ModelConfiguration(isStoredInMemoryOnly: true)
+		let container = try ModelContainer(for: Exercise.self, configurations: config)
+
+		let actor = ExerciseList.Service(modelContainer: container)
+
+		let exercise1 = Exercise(name: "abc")
+		let exercise2 = Exercise(name: "bcd")
+		let exercise3 = Exercise(name: "XYZ")
+		let exercise4 = Exercise(name: "XZY")
+
+		let expectedList: [Exercise] = [
+			exercise1,
+			exercise2,
+			exercise3,
+			exercise4
+		]
+
+		let sut = ExerciseList(name: "Test", exercises: [
+			exercise3,
+			exercise1,
+			exercise4,
+			exercise2
+		])
+
+		sut.sortExercises(by: .alphabetical)
+
+		#expect(sut.exercises == expectedList)
+    }
+}

--- a/AppPackages/DataStorage/Tests/DataStorageTests/ExerciseListTests.swift
+++ b/AppPackages/DataStorage/Tests/DataStorageTests/ExerciseListTests.swift
@@ -14,7 +14,7 @@ import Testing
 import SwiftData
 @testable import DataStorage
 
-struct ExcerciseListTests {
+struct ExerciseListTests {
     @Test("Sort all exercises in list alphabetically")
 	func sortingExercisesAlphabetically() async throws {
 		let config = ModelConfiguration(isStoredInMemoryOnly: true)
@@ -41,7 +41,7 @@ struct ExcerciseListTests {
 			exercise2
 		])
 
-		sut.sortExercises(by: .alphabetical)
+		sut.sort(by: .alphabetical)
 
 		#expect(sut.exercises == expectedList)
     }

--- a/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseListDetailView.swift
+++ b/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseListDetailView.swift
@@ -52,7 +52,9 @@ struct ExerciseListDetailView: View {
 		.toolbar {
 			ToolbarItem(placement: .primaryAction) {
 				Menu("Menu", systemImage: "note.text") {
-					Button {} label: {
+					Button {
+						exerciseList.sort(by: .alphabetical)
+					} label: {
 						Text("Alphabetical")
 					}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Your title should be in the format of "feat(scope): description" -->

## Description
<!--- Describe your changes in detail -->
This PR adds the option to sort the exercises in a list by pressing the `Alphabetical` button in the topbar menu

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
- Closes #25 
<!--- If suggesting a new feature or change, please discuss it in a discussion first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- If this Pull Request closes an issue, please add `Closes #XXXX` -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- The feature was tested on the simulator
- A unit test was written

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Only one box should be checked -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer tooling (fix or improve developer tooling)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
