### PR TITLE
feat: :sparkles: add a setting for rest time

### DIFF
--- a/AppPackages/Settings/Sources/Settings/SettingsView.swift
+++ b/AppPackages/Settings/Sources/Settings/SettingsView.swift
@@ -21,21 +21,24 @@ public struct SettingsView: View {
 
     public var body: some View {
         NavigationStack {
-            HStack {
-                Text("Rest")
-                    .bold()
-                Picker("", selection: $restTimeMinutes) {
-                    ForEach(0...5, id: \.self) {
-                        Text("\($0)")
+            List {
+                HStack {
+                    Text("Rest")
+                        .bold()
+                    Picker("", selection: $restTimeMinutes) {
+                        ForEach(0...5, id: \.self) {
+                            Text("\($0)")
+                        }
                     }
-                }
-                Text(restTimeMinutes <= 1 ? "minute" : "minutes")
-                Picker("", selection: $restTimeSeconds) {
-                    ForEach(Array(stride(from: 0, to: 60, by: 5)), id: \.self) {
-                        Text("\($0)")
+                    Text(restTimeMinutes <= 1 ? "minute" : "minutes")
+                    Picker("", selection: $restTimeSeconds) {
+                        ForEach(Array(stride(from: 0, to: 60, by: 5)), id: \.self) {
+                            Text("\($0)")
+                        }
                     }
+                    Text("seconds")
+                        .fixedSize(horizontal: true, vertical: false)
                 }
-                Text("seconds")
             }.navigationTitle("Settings")
         }
     }

--- a/AppPackages/Settings/Sources/Settings/SettingsView.swift
+++ b/AppPackages/Settings/Sources/Settings/SettingsView.swift
@@ -14,16 +14,33 @@ import SwiftUI
 
 public struct SettingsView: View {
 
-	public init() {}
+    @AppStorage("restTimeMinutes") private var restTimeMinutes = 1
+    @AppStorage("restTimeSeconds") private var restTimeSeconds = 5
 
-	public var body: some View {
-		NavigationStack {
-			Text("This is the Settings View")
-				.navigationTitle("Settings")
-		}
-	}
+    public init() {}
+
+    public var body: some View {
+        NavigationStack {
+            HStack {
+                Text("Rest")
+                    .bold()
+                Picker("", selection: $restTimeMinutes) {
+                    ForEach(0...5, id: \.self) {
+                        Text("\($0)")
+                    }
+                }
+                Text(restTimeMinutes <= 1 ? "minute" : "minutes")
+                Picker("", selection: $restTimeSeconds) {
+                    ForEach(Array(stride(from: 0, to: 60, by: 5)), id: \.self) {
+                        Text("\($0)")
+                    }
+                }
+                Text("seconds")
+            }.navigationTitle("Settings")
+        }
+    }
 }
 
 #Preview {
-	SettingsView()
+    SettingsView()
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Your title should be in the format of "feat(scope): description" -->

## Description
In settings you can now pick a rest time in minutes and seconds. These values are stored to the AppStorage under `restTimeMinutes` and `restTimeSeconds`. SwiftUI currently doesn’t have a time picker that doesn’t show AM / PM. I could’ve used a UIKIT picker, but I thought this looked good enough.

### Related Issue
https://github.com/heyjaywilson/peakfit/issues/22
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in a discussion first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- If this Pull Request closes an issue, please add `Closes #XXXX` -->

## How Has This Been Tested?
Picked various values from the settings screen and varied they are still set on relaunch and navigating back and forth. 

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/e1bff3f0-ddd2-4e95-ada1-7663ca13bcbf

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Only one box should be checked -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer tooling (fix or improve developer tooling)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
