### PR TITLE
fix(exercises): :bug: Swiping to delete an exercise only deletes the exercise from the list and not from the app

### DIFF
--- a/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseListDetailView.swift
+++ b/AppPackages/Exercises/Sources/Exercises/ExerciseLists/ExerciseListDetailView.swift
@@ -79,15 +79,17 @@ struct ExerciseListDetailView: View {
 
 extension ExerciseListDetailView {
 	func deleteExercise(_ exercise: Exercise) {
-		let exerciseID = exercise.persistentModelID
-		let container = modelContext.container
-		Task.detached(priority: .userInitiated) {
-			let service = Exercise.Service(modelContainer: container)
-			do {
-				try await service.delete(for: [exerciseID])
-			} catch {
-				print(#file, #function, "Error deleting exercise: \(error)")
-			}
-		}
-	}
+        let container = modelContext.container
+        let exerciseListID = exerciseList.id
+        let exerciseID = exercise.id
+
+        Task.detached(priority: .userInitiated) {
+            let service = ExerciseList.Service(modelContainer: container)
+            do {
+                try await service.addOrRemoveExercise(exerciseID: exerciseID, from: exerciseListID)
+            } catch {
+                print("🚨 \(#function) \(#file) Error adding exercise to list: \(error)")
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Your title should be in the format of "feat(scope): description" -->

## Description
<!--- Describe your changes in detail -->

When deleting an exercise from the list using the swipe gesture, the exercise was not only deleted from the list but from the "All exercises" list.

Fixing it so it only deletes the exercise from the list but it is still available to be used again in any of the lists. 

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in a discussion first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- If this Pull Request closes an issue, please add `Closes #XXXX` -->

Closes #68 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

When deleting an exercise from the list, if you then go check the list of exercises, the exercise is still there. 

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Only one box should be checked -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer tooling (fix or improve developer tooling)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
